### PR TITLE
fix: ResetTotalBurned amount validation

### DIFF
--- a/x/distribution/client/cli/tx.go
+++ b/x/distribution/client/cli/tx.go
@@ -422,14 +422,14 @@ $ %s tx distribution change-moderator [new_moderator_address] --from [moderator_
 // NewResetTotalBurnedCmd returns a CLI command handler for creating a MsgResetTotalBurned transaction.
 func NewResetTotalBurnedCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "reset-total-burned [denom] [amount]",
+		Use:   "reset-total-burned [coin]",
 		Args:  cobra.ExactArgs(1),
 		Short: "Resets the total burned amount for the given denom",
 		Long: strings.TrimSpace(
 			fmt.Sprintf(`Resets the total burned amount for the given denom
 
 Example:
-$ %s tx distribution reset-total-burned [denom] [amount] --from [moderator_address]
+$ %s tx distribution reset-total-burned [coin] --from [moderator_address]
 `,
 				version.AppName,
 			),

--- a/x/distribution/keeper/msg_server.go
+++ b/x/distribution/keeper/msg_server.go
@@ -222,6 +222,10 @@ func (k msgServer) ResetTotalBurned(goCtx context.Context, msg *types.MsgResetTo
 		return nil, types.ErrInvalidModerator.Wrapf("invalid moderator address. expected: %s, got: %s", moderator.Address, msg.ModeratorAddress)
 	}
 
+	if msg.Amount.IsNil() || msg.Amount.IsNegative() {
+		return nil, errors.Wrapf(sdkerrors.ErrInvalidRequest, "amount cannot be nil or negative")
+	}
+
 	// get the total burned amount
 	totalBurned := k.Keeper.GetTotalBurned(ctx)
 


### PR DESCRIPTION
## Description
fix the issue with `ResetTotalBurned` amount validation. Reset is possible if the amount is 0 or bigger.