### PR TITLE
fix: calculate community fee before ratio

### DIFF
--- a/x/distribution/types/events.go
+++ b/x/distribution/types/events.go
@@ -14,6 +14,8 @@ const (
 	EventTypeBurnFee            = "burn_fee"
 	EventTypeBaseFee            = "base_fee"
 	EventTypeStakingRewards     = "staking_rewards"
+	EventTypeCommunityPool      = "community_pool"
+	EventTypeTotalFees          = "total_fees"
 
 	AttributeKeyWithdrawAddress = "withdraw_address"
 	AttributeKeyValidator       = "validator"


### PR DESCRIPTION
## Description
Fix for the [sherlock audit issue #143](https://github.com/sherlock-audit/2025-09-gurufin-chain/issues/143)

I have
- moved the community pool fee calculation before the distribution ratio
- optimized the logs