### PR TITLE
Audit/fix/issue 144

### DIFF
--- a/x/distribution/keeper/allocation.go
+++ b/x/distribution/keeper/allocation.go
@@ -50,7 +50,7 @@ func (k Keeper) AllocateTokens(ctx context.Context, totalPreviousPower int64, bo
 		burnFeeDec := sdk.NewDecCoinsFromCoins(burnFee...)
 		err = k.bankKeeper.BurnCoins(ctx, types.ModuleName, burnFee)
 		if err != nil {
-			panic(err)
+			return err
 		}
 		remaining = remaining.Sub(burnFeeDec)
 		err = k.AddTotalBurned(ctx, burnFee)
@@ -79,7 +79,7 @@ func (k Keeper) AllocateTokens(ctx context.Context, totalPreviousPower int64, bo
 			baseFeeDec = sdk.NewDecCoinsFromCoins(baseFee...)
 			err = k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, baseAddr, baseFee)
 			if err != nil {
-				panic(err)
+				return err
 			}
 			remaining = remaining.Sub(baseFeeDec)
 			// emit base fee


### PR DESCRIPTION
## Description
Fix for the [sherlock audit issue #144](https://github.com/sherlock-audit/2025-09-gurufin-chain/issues/144)

I have
- replaced the `panic(err)` with `return err`